### PR TITLE
Delegate database_url string parsing to PG

### DIFF
--- a/lib/ruby-pg-extras.rb
+++ b/lib/ruby-pg-extras.rb
@@ -159,15 +159,7 @@ module RubyPGExtras
   end
 
   def self.connection
-    database_uri = URI.parse(database_url)
-
-    @_connection ||= PG.connect(
-      dbname: database_uri.path[1..-1],
-      host: database_uri.host,
-      port: database_uri.port,
-      user: database_uri.user,
-      password: database_uri.password
-    )
+    @_connection ||= PG.connect(database_url)
   end
 
   def self.database_url=(value)


### PR DESCRIPTION
Hello! First off, thank you for this library.

I'm having trouble using it with an Azure hosted postgres database, which defaults to a username of the format `username@hostname`. In order to satisfy the URI.parse here: https://github.com/pawurb/ruby-pg-extras/blob/master/lib/ruby-pg-extras.rb#L162, you have to escape the `@` with a `%40`. That escaped value doesn't get unescaped here: https://github.com/pawurb/ruby-pg-extras/blob/master/lib/ruby-pg-extras.rb#L168, which causes the connection to fail.

Is there any appetite for utilizing the full `PG.connect` parsing behavior, similar to ActiveRecord in Rails? It handles a few different use cases, including the one advertised in ruby-pg-extra's README.md. It also handles my edge case. This is what I mean: https://github.com/ged/ruby-pg/blob/master/lib/pg/connection.rb#L80-L93.

Thanks again!