### PR TITLE
Switch to cimg images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,24 +2,24 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/ruby:2.6.5
+      - image: cimg/ruby:2.6
         environment:
           DATABASE_URL: postgresql://postgres:secret@localhost:5432/ruby-pg-extras-test
-      - image: circleci/postgres:11.5
+      - image: cimg/postgres:11.15
         command: postgres -c shared_preload_libraries=pg_stat_statements
         name: postgres11
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: ruby-pg-extras-test
           POSTGRES_PASSWORD: secret
-      - image: circleci/postgres:12.7
+      - image: cimg/postgres:12.10
         command: postgres -c shared_preload_libraries=pg_stat_statements
         name: postgres12
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: ruby-pg-extras-test
           POSTGRES_PASSWORD: secret
-      - image: circleci/postgres:13.3
+      - image: cimg/postgres:13.6
         command: postgres -c shared_preload_libraries=pg_stat_statements
         name: postgres13
         environment:


### PR DESCRIPTION
Circle CI is no longer supporting the Docker images with a `circleci` prefix.  The newer, supported images have a `cimg` prefix.

This PR changes the prefix.  It also migrates to the latest patch version for each Ruby and Postgres image.