### PR TITLE
Fix #12 - Eliminate filesize dependency

### DIFF
--- a/lib/ruby-pg-extras.rb
+++ b/lib/ruby-pg-extras.rb
@@ -3,6 +3,7 @@
 require 'terminal-table'
 require 'uri'
 require 'pg'
+require 'ruby_pg_extras/size_parser'
 require 'ruby_pg_extras/diagnose_data'
 require 'ruby_pg_extras/diagnose_print'
 require 'ruby_pg_extras/index_info'

--- a/lib/ruby_pg_extras/diagnose_data.rb
+++ b/lib/ruby_pg_extras/diagnose_data.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-require 'filesize'
-
 module RubyPgExtras
   class DiagnoseData
     PG_EXTRAS_TABLE_CACHE_HIT_MIN_EXPECTED = "0.985"
     PG_EXTRAS_INDEX_CACHE_HIT_MIN_EXPECTED = "0.985"
     PG_EXTRAS_UNUSED_INDEXES_MAX_SCANS = 20
-    PG_EXTRAS_UNUSED_INDEXES_MIN_SIZE_BYTES = Filesize.from("1 MB").to_i # 1000000 bytes
+    PG_EXTRAS_UNUSED_INDEXES_MIN_SIZE_BYTES = SizeParser.to_i("1 MB") # 1000000 bytes
     PG_EXTRAS_NULL_INDEXES_MIN_SIZE_MB = 1 # 1 MB
     PG_EXTRAS_NULL_MIN_NULL_FRAC_PERCENT = 50 # 50%
     PG_EXTRAS_BLOAT_MIN_VALUE = 10
@@ -118,7 +116,7 @@ module RubyPgExtras
         in_format: :hash,
         args: { min_scans: PG_EXTRAS_UNUSED_INDEXES_MAX_SCANS }
       ).select do |i|
-        Filesize.from(i.fetch("index_size").sub("bytes", "").strip).to_i >= PG_EXTRAS_UNUSED_INDEXES_MIN_SIZE_BYTES
+        SizeParser.to_i(i.fetch("index_size").strip) >= PG_EXTRAS_UNUSED_INDEXES_MIN_SIZE_BYTES
       end
 
       if indexes.count == 0

--- a/lib/ruby_pg_extras/size_parser.rb
+++ b/lib/ruby_pg_extras/size_parser.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module RubyPgExtras
+  class SizeParser
+    def self.to_i(arg)
+      value = to_i_si(arg) || to_i_binary(arg) || to_i_digits(arg)
+      raise ArgumentError, "Unparseable size: #{arg}" if value.nil?
+
+      value
+    end
+
+    def self.regexp_for_units(units)
+      /\A(-?\d+)\s?(#{units.join('|')})\z/i
+    end
+
+    SI_UNITS = %w[bytes kB MB GB TB PB EB ZB YB].map(&:downcase).freeze
+    SI_REGEXP = regexp_for_units(SI_UNITS)
+
+    def self.to_i_si(arg)
+      to_i_for_units(arg, SI_REGEXP, SI_UNITS, 1000)
+    end
+
+    BINARY_UNITS = %w[bytes KiB MiB GiB TiB PiB EiB ZiB YiB].map(&:downcase).freeze
+    BINARY_REGEXP = regexp_for_units(BINARY_UNITS)
+
+    def self.to_i_binary(arg)
+      to_i_for_units(arg, BINARY_REGEXP, BINARY_UNITS, 1024)
+    end
+
+    def self.to_i_for_units(arg, regexp, units, multiplier)
+      match_data = regexp.match(arg)
+      return nil unless match_data
+
+      exponent = units.index(match_data[2].downcase).to_i
+      match_data[1].to_i * multiplier**exponent
+    end
+
+    DIGITS_ONLY_REGEXP = /\A(-?\d+)\z/.freeze
+    def self.to_i_digits(arg)
+      DIGITS_ONLY_REGEXP.match?(arg) ? arg.to_i : nil
+    end
+  end
+end

--- a/ruby-pg-extras.gemspec
+++ b/ruby-pg-extras.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.license       = "MIT"
   s.add_dependency "pg"
-  s.add_dependency "filesize"
   s.add_dependency "terminal-table"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"

--- a/spec/size_parser_spec.rb
+++ b/spec/size_parser_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RubyPgExtras::SizeParser do
+  subject(:result) { described_class.to_i(arg) }
+
+  describe 'SI Units' do
+    let(:arg) { "#{num_units} #{unit}" }
+
+    context "when the argument is a number followed by 'bytes', with possible case variations" do
+      let(:num_units) { rand(1000) }
+      let(:unit) { %w[bytes BYTES Bytes].sample }
+
+      it { is_expected.to eq(num_units) }
+    end
+
+    context "when the argument is a number followed by 'kB', with possible case variations" do
+      let(:num_units) { rand(1000) }
+      let(:unit) { %w[kB kb KB].sample }
+
+      it { is_expected.to eq(num_units * 1000) }
+    end
+
+    context "when the argument is a number followed by 'MB', with possible case variations" do
+      let(:num_units) { rand(1000) }
+      let(:unit) { %w[MB Mb mb].sample }
+
+      it { is_expected.to eq(num_units * 1000 * 1000) }
+    end
+
+    context "when the argument is a number followed by 'GB', with possible case variations" do
+      let(:num_units) { rand(1000) }
+      let(:unit) { %w[GB Gb gb].sample }
+
+      it { is_expected.to eq(num_units * 1000 * 1000 * 1000) }
+    end
+
+    context "when the argument is a number followed by 'TB', with possible case variations" do
+      let(:num_units) { rand(1000) }
+      let(:unit) { %w[TB Tb tb].sample }
+
+      it { is_expected.to eq(num_units * 1000 * 1000 * 1000 * 1000) }
+    end
+
+    context "when the argument is a number followed by 'PB', with possible case variations" do
+      let(:num_units) { rand(1000) }
+      let(:unit) { %w[PB Pb pb].sample }
+
+      it { is_expected.to eq(num_units * 1000 * 1000 * 1000 * 1000 * 1000) }
+    end
+
+    context "when the argument is a number followed by 'EB', with possible case variations" do
+      let(:num_units) { rand(1000) }
+      let(:unit) { %w[EB Eb eb].sample }
+
+      it { is_expected.to eq(num_units * 1000 * 1000 * 1000 * 1000 * 1000 * 1000) }
+    end
+
+    context "when the argument is a number followed by 'ZB', with possible case variations" do
+      let(:num_units) { 912 }
+      let(:unit) { %w[ZB Zb zb].sample }
+
+      it { is_expected.to eq(num_units * 1000 * 1000 * 1000 * 1000 * 1000 * 1000 * 1000) }
+    end
+
+    context "when the argument is a number followed by 'YB', with possible case variations" do
+      let(:num_units) { 912 }
+      let(:unit) { %w[YB Yb yb].sample }
+
+      it { is_expected.to eq(num_units * 1000 * 1000 * 1000 * 1000 * 1000 * 1000 * 1000 * 1000) }
+    end
+  end
+
+  describe 'Binary Units' do
+    let(:arg) { "#{num_units} #{unit}" }
+
+    context "when the argument is a number followed by 'bytes', with possible case variations" do
+      let(:num_units) { rand(1000) }
+      let(:unit) { %w[bytes BYTES Bytes].sample }
+
+      it { is_expected.to eq(num_units) }
+    end
+
+    context "when the argument is a number followed by 'kiB', with possible case variations" do
+      let(:num_units) { rand(1000) }
+      let(:unit) { %w[kiB kib KiB].sample }
+
+      it { is_expected.to eq(num_units * 1024) }
+    end
+
+    context "when the argument is a number followed by 'MiB', with possible case variations" do
+      let(:num_units) { rand(1000) }
+      let(:unit) { %w[MiB Mib mib].sample }
+
+      it { is_expected.to eq(num_units * 1024 * 1024) }
+    end
+
+    context "when the argument is a number followed by 'GiB', with possible case variations" do
+      let(:num_units) { rand(1000) }
+      let(:unit) { %w[GiB Gib gib].sample }
+
+      it { is_expected.to eq(num_units * 1024 * 1024 * 1024) }
+    end
+
+    context "when the argument is a number followed by 'TiB', with possible case variations" do
+      let(:num_units) { rand(1000) }
+      let(:unit) { %w[TiB Tib tib].sample }
+
+      it { is_expected.to eq(num_units * 1024 * 1024 * 1024 * 1024) }
+    end
+
+    context "when the argument is a number followed by 'PiB', with possible case variations" do
+      let(:num_units) { rand(1000) }
+      let(:unit) { %w[PiB Pib pib].sample }
+
+      it { is_expected.to eq(num_units * 1024 * 1024 * 1024 * 1024 * 1024) }
+    end
+
+    context "when the argument is a number followed by 'EiB', with possible case variations" do
+      let(:num_units) { rand(1000) }
+      let(:unit) { %w[EiB Eib eib].sample }
+
+      it { is_expected.to eq(num_units * 1024 * 1024 * 1024 * 1024 * 1024 * 1024) }
+    end
+
+    context "when the argument is a number followed by 'ZB', with possible case variations" do
+      let(:num_units) { 912 }
+      let(:unit) { %w[ZiB Zib zib].sample }
+
+      it { is_expected.to eq(num_units * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024) }
+    end
+
+    context "when the argument is a number followed by 'YB', with possible case variations" do
+      let(:num_units) { 912 }
+      let(:unit) { %w[YiB Yib yib].sample }
+
+      it { is_expected.to eq(num_units * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024) }
+    end
+  end
+
+  context 'when the argument has only digits' do
+    let(:arg) { '654245' }
+
+    it { is_expected.to eq(arg.to_i) }
+  end
+
+  describe 'errors' do
+    it 'raises an error when the argument has an invalid prefix' do
+      expect do
+        described_class.to_i('123 qb')
+      end.to raise_error ArgumentError
+    end
+
+    it 'raises an error when the argument does not have a unit in bytes' do
+      expect do
+        described_class.to_i('123 mL')
+      end.to raise_error ArgumentError
+    end
+
+    it 'when the argument cannot be parsed an number of units' do
+      expect do
+        described_class.to_i('1c3 MB')
+      end.to raise_error ArgumentError
+    end
+  end
+end


### PR DESCRIPTION
This commit eliminates the dependency on the now unsupported filesize gem.  The parsing functionality from that gem is now handled with a dedicated SizeParser class.