### PR TITLE
Adds Postgres 14 to the development and testing environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,13 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_DB: ruby-pg-extras-test
           POSTGRES_PASSWORD: secret
+      - image: cimg/postgres:14.2
+        command: postgres -c shared_preload_libraries=pg_stat_statements
+        name: postgres13
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: ruby-pg-extras-test
+          POSTGRES_PASSWORD: secret
     parallelism: 1
     steps:
       - checkout
@@ -50,6 +57,11 @@ jobs:
           name: Run specs for PG 13
           environment:
             DATABASE_URL: postgresql://postgres:secret@postgres13:5432/ruby-pg-extras-test
+          command: bundle exec rspec spec/
+      - run:
+          name: Run specs for PG 14
+          environment:
+            DATABASE_URL: postgresql://postgres:secret@postgres14:5432/ruby-pg-extras-test
           command: bundle exec rspec spec/
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           POSTGRES_PASSWORD: secret
       - image: cimg/postgres:14.2
         command: postgres -c shared_preload_libraries=pg_stat_statements
-        name: postgres13
+        name: postgres14
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: ruby-pg-extras-test

--- a/Rakefile
+++ b/Rakefile
@@ -5,5 +5,5 @@ RSpec::Core::RakeTask.new(:spec)
 
 desc 'Test all PG versions'
 task :test_all do
-  system("PG_VERSION=11 bundle exec rspec spec/ && PG_VERSION=12 bundle exec rspec spec/ && PG_VERSION=13 bundle exec rspec spec/")
+  system("PG_VERSION=11 bundle exec rspec spec/ && PG_VERSION=12 bundle exec rspec spec/ && PG_VERSION=13 bundle exec rspec spec/ && PG_VERSION=14 bundle exec rspec spec/")
 end

--- a/docker-compose.yml.sample
+++ b/docker-compose.yml.sample
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres11:
-    image: postgres:11.5-alpine
+    image: postgres:11.16-alpine
     command: postgres -c shared_preload_libraries=pg_stat_statements
     environment:
       POSTGRES_USER: postgres
@@ -11,7 +11,7 @@ services:
     ports:
       - '5432:5432'
   postgres12:
-    image: postgres:12.7-alpine
+    image: postgres:12.11-alpine
     command: postgres -c shared_preload_libraries=pg_stat_statements
     environment:
       POSTGRES_USER: postgres
@@ -20,7 +20,7 @@ services:
     ports:
       - '5433:5432'
   postgres13:
-    image: postgres:13.3-alpine
+    image: postgres:13.7-alpine
     command: postgres -c shared_preload_libraries=pg_stat_statements
     environment:
       POSTGRES_USER: postgres
@@ -28,3 +28,12 @@ services:
       POSTGRES_PASSWORD: secret
     ports:
       - '5434:5432'
+  postgres14:
+    image: postgres:14.3-alpine
+    command: postgres -c shared_preload_libraries=pg_stat_statements
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: ruby-pg-extras-test
+      POSTGRES_PASSWORD: secret
+    ports:
+      - '5435:5432'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ elsif pg_version == "12"
   "5433"
 elsif pg_version == "13"
   "5434"
+elsif pg_version == "14"
+  "5435"
 else
   "5432"
 end


### PR DESCRIPTION
Postgres 14 has been out for a while (14.3 was released in May 2022).  This PR adds Postgres 14 to the set of Docker images that are created and used for local testing and to Circle CI.