### PR TITLE
Support scenario where sslinfo is not installed on the server

### DIFF
--- a/lib/ruby_pg_extras/diagnose_data.rb
+++ b/lib/ruby_pg_extras/diagnose_data.rb
@@ -25,13 +25,15 @@ module RubyPgExtras
         :duplicate_indexes
       ].yield_self do |checks|
         extensions_data = query_module.extensions(in_format: :hash)
+
         pg_stats_enabled = extensions_data.find do |el|
           el.fetch("name") == "pg_stat_statements"
         end.fetch("installed_version", false)
 
-        ssl_info_enabled = extensions_data.find do |el|
+        ssl_info = extensions_data.find do |el|
           el.fetch("name") == "sslinfo"
-        end.fetch("installed_version", false)
+        end
+        ssl_info_enabled = ssl_info != nil && ssl_info.fetch("installed_version", false)
 
         if pg_stats_enabled
           checks = checks.concat([:outliers])

--- a/lib/ruby_pg_extras/version.rb
+++ b/lib/ruby_pg_extras/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubyPgExtras
-  VERSION = "4.12.0"
+  VERSION = "4.12.1"
 end


### PR DESCRIPTION
It seems that in some cases (Azure ..) that the `sslinfo` extension is not installed (not available).

This PR makes a small change so that there isn't a nil exception raised in the event that `sslinfo` is not found.

In support of issue #19. If this change does make sense, I also needed to bump the version of `rails-pg-extras` in order for the root issue to be solved.