### PR TITLE
Fix detection of columns of partial indexes

### DIFF
--- a/lib/ruby_pg_extras/queries/indexes.sql
+++ b/lib/ruby_pg_extras/queries/indexes.sql
@@ -4,6 +4,6 @@ SELECT
   schemaname,
   indexname,
   tablename,
-  rtrim(split_part(indexdef, '(', 2), ')') as columns
+  rtrim(split_part(split_part(indexdef, ' WHERE', 1), '(', 2), ')') as columns
 FROM pg_indexes
 where tablename in (select relname from pg_statio_user_tables);


### PR DESCRIPTION
The columns of a partial index like this

```sql
CREATE INDEX index_mytable_on_user_id ON public.mytable USING btree (user_id) WHERE (user_id IS NOT NULL)
```
are returned as `user_id) WHERE`. The subsequent check `missing_fk_indexes` fails accordingly.

This change truncates `indexdef` at the `where` clause (or the end, if it is missing), then continues applying the previous logic. 
