### PR TITLE
Performance: fetch schemas and foreign keys for all tables in single query

### DIFF
--- a/lib/ruby-pg-extras.rb
+++ b/lib/ruby-pg-extras.rb
@@ -29,7 +29,8 @@ module RubyPgExtras
     unused_indexes duplicate_indexes vacuum_stats kill_all kill_pid
     pg_stat_statements_reset buffercache_stats
     buffercache_usage ssl_used connections
-    table_schema table_foreign_keys
+    table_schema table_schemas
+    table_foreign_keys foreign_keys
   )
 
   DEFAULT_SCHEMA = ENV["PG_EXTRAS_SCHEMA"] || "public"
@@ -57,12 +58,14 @@ module RubyPgExtras
     index_cache_hit: { schema: DEFAULT_SCHEMA },
     table_cache_hit: { schema: DEFAULT_SCHEMA },
     table_size: { schema: DEFAULT_SCHEMA },
+    table_schemas: { schema: DEFAULT_SCHEMA },
     index_scans: { schema: DEFAULT_SCHEMA },
     cache_hit: { schema: DEFAULT_SCHEMA },
     seq_scans: { schema: DEFAULT_SCHEMA },
     table_index_scans: { schema: DEFAULT_SCHEMA },
     records_rank: { schema: DEFAULT_SCHEMA },
     tables: { schema: DEFAULT_SCHEMA },
+    foreign_keys: { schema: DEFAULT_SCHEMA },
     kill_pid: { pid: 0 },
   })
 

--- a/lib/ruby_pg_extras/missing_fk_indexes.rb
+++ b/lib/ruby_pg_extras/missing_fk_indexes.rb
@@ -14,10 +14,11 @@ module RubyPgExtras
         end
 
       indexes_info = query_module.indexes(in_format: :hash)
+      schemas = query_module.table_schemas(in_format: :hash)
 
       tables.reduce([]) do |agg, table|
         index_info = indexes_info.select { |row| row.fetch("tablename") == table }
-        schema = query_module.table_schema(args: { table_name: table }, in_format: :hash)
+        schema = schemas.select { |row| row.fetch("table_name") == table }
 
         fk_columns = schema.filter_map do |row|
           if DetectFkColumn.call(row.fetch("column_name"), all_tables)

--- a/lib/ruby_pg_extras/queries/foreign_keys.sql
+++ b/lib/ruby_pg_extras/queries/foreign_keys.sql
@@ -1,0 +1,19 @@
+/* Foreign keys info for all tables  */
+
+SELECT 
+    conrelid::regclass AS table_name,
+    conname AS constraint_name,
+    a.attname AS column_name,
+    confrelid::regclass AS foreign_table_name,
+    af.attname AS foreign_column_name
+FROM 
+    pg_constraint AS c
+JOIN 
+    pg_attribute AS a ON a.attnum = ANY(c.conkey) AND a.attrelid = c.conrelid
+JOIN 
+    pg_attribute AS af ON af.attnum = ANY(c.confkey) AND af.attrelid = c.confrelid
+JOIN
+    pg_namespace AS n ON n.oid = c.connamespace
+WHERE 
+    c.contype = 'f'
+    AND n.nspname = '%{schema}';

--- a/lib/ruby_pg_extras/queries/table_schemas.sql
+++ b/lib/ruby_pg_extras/queries/table_schemas.sql
@@ -1,0 +1,5 @@
+/* Column names and types for all tables */
+
+SELECT table_name, column_name, data_type, is_nullable, column_default 
+  FROM information_schema.columns 
+  WHERE table_schema = '%{schema}';


### PR DESCRIPTION
Adds 2 new queries and updates `missing_fk_indexes` and `missing_fk_constraints` to fetch schema and foreign key data for all tables in a single shot. This makes running these operations for a single table a little slower, but for all tables much faster.