### PR TITLE
Add ability to reset connection

### DIFF
--- a/lib/ruby-pg-extras.rb
+++ b/lib/ruby-pg-extras.rb
@@ -247,6 +247,8 @@ module RubyPgExtras
   end
 
   def self.database_url=(value)
+    @_connection&.close
+    @_connection = nil
     @@database_url = value
   end
 

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -65,5 +65,17 @@ describe RubyPgExtras do
         RubyPgExtras.bloat(in_format: :hash)
       end.not_to raise_error
     end
+
+    it "resets the connection when setting database URL" do
+      old_connection = RubyPgExtras.connection
+      expect(old_connection).not_to be_finished
+
+      RubyPgExtras.database_url = ENV.fetch("DATABASE_URL")
+
+      expect(old_connection).to be_finished
+      new_connection = RubyPgExtras.connection
+      expect(new_connection).not_to eq(old_connection)
+      expect(new_connection).not_to be_finished
+    end
   end
 end


### PR DESCRIPTION
Hello! Thanks for this gem :)

I'm wondering if you are interested into merging something like this. If so, I will try to add a test too.

Why do I think this method is useful?

Because I have a Rails application that uses multiple databases and I'm writing a rake task that wraps ruby-pg-extras and run the `bloat` command for each of our databases (5 databases at the moment).

Since the connection object is memoized, I'm not able to reset it after `RubyPgExtras.database_url=` as been called the first time. So, by being able to reset the connection, I'm able to call `RubyPgExtras.database_url=` multiple times, one for each database

What do you think? Is it something that you might consider?

